### PR TITLE
Improve BTC unit format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Bitcoin Price Tag
 
-Automatically annotate fiat prices online with their equivalents in bitcoin. Download the Chrome extension [here](https://chrome.google.com/webstore/detail/bitcoin-price-tag/phjlopbkegpphenpgimnlckfmjfanceh).
+Chrome extension to automatically annotate fiat prices online with their equivalents in bitcoin.
+
+<img width="269" alt="Screen Shot 2021-10-05 at 5 10 13 PM" src="https://user-images.githubusercontent.com/3598502/138306555-d368d939-02a6-4365-8036-22e7e305fcde.png">
+<img width="635" alt="Screen Shot 2021-10-05 at 5 11 49 PM" src="https://user-images.githubusercontent.com/3598502/138306557-dee94fba-1982-44a6-b208-4c8cd0490f0b.png">
 
 ## Under the Hood
 
 **Bitcoin Price Tag** uses the CoinDesk API to fetch the current price of bitcoin and uses that to convert fiat-denominated prices to bitcoin.
+
+Fork of the original extension published [here](https://chrome.google.com/webstore/detail/bitcoin-price-tag/phjlopbkegpphenpgimnlckfmjfanceh).
 
 ## License
 

--- a/content.js
+++ b/content.js
@@ -39,13 +39,34 @@ const valueInBtc = (fiatAmount) => {
   return parseFloat((fiatAmount / btcPrice).toFixed(4)).toLocaleString();
 };
 
+// [min magnitude, denominator magnitude, suffix]
+const friendlySuffixes = [
+  [0, 0, ' sats'],
+  [4, 3, 'k sats'],
+  [6, 6, 'M sats'],
+  [8, 8, ' BTC'],
+  [12, 11, 'k BTC'],
+  [14, 14, 'M BTC'],
+]
+function round(x, y) { return Math.round(x * 10 ** y) / 10 ** y }
+const valueFriendly = (fiatAmount) => {
+  let sats = Math.floor(fiatAmount / satPrice)
+  let m = String(sats).length
+  let si = friendlySuffixes.findIndex(([l]) => l >= m)
+  si = si < 0 ? friendlySuffixes.length : si
+  let [l, d, suffix] = friendlySuffixes[si - 1]
+  let roundDigits = Math.max(0, 3 - (m - d))
+  return round(sats / 10 ** d, roundDigits).toLocaleString() + suffix
+}
+
 // Build text element in the form of: original (conversion)
 const makeSnippet = (sourceElement, fiatAmount) => {
-  if (fiatAmount >= btcPrice) {
+  /*if (fiatAmount >= btcPrice) {
     return `${sourceElement} (${valueInBtc(fiatAmount)} BTC) `;
   } else {
     return `${sourceElement} (${valueInSats(fiatAmount)} sats) `;
-  }
+  }*/
+  return `${sourceElement} (${valueFriendly(fiatAmount)}) `
 };
 
 const getMultiplier = (e) => {
@@ -133,7 +154,7 @@ const walk = (node) => {
 };
 
 // Run on page load
-(setTimeout(() => {
+(window.setTimeout(() => {
   // Get current price of bitcoin in USD
   fetch("https://api.coindesk.com/v1/bpi/currentprice/USD.json")
     .then((response) => response.json())


### PR DESCRIPTION
Makes BTC prices more compact by rounding and formatting sats/BTC amounts with ISO suffixes (k/M)

<img width="635" alt="Screen Shot 2021-10-05 at 5 11 49 PM" src="https://user-images.githubusercontent.com/3598502/136104725-9b76917b-747f-45d4-a71a-1e4ce1b943ef.png">
<img width="269" alt="Screen Shot 2021-10-05 at 5 10 13 PM" src="https://user-images.githubusercontent.com/3598502/136104726-f3c3cad9-d94a-438f-bf3f-641312f25056.png">
